### PR TITLE
Allow running init even when some files already exist

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,13 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### Changed
-
-- Improved error messages for missing files [#7](https://github.com/p2panda/fishy/pull/7)
-
 ### Added
 
 * Allow relating to schemas via `id` [#4](https://github.com/p2panda/fishy/issues/4)
+
+### Changed
+
+* Improved error messages for missing files [#7](https://github.com/p2panda/fishy/pull/7)
+* Allow running `init` even when private key or schema file already exists [#8](https://github.com/p2panda/fishy/pull/8)
+
 
 ## [0.1.0]
 

--- a/src/commands/init.rs
+++ b/src/commands/init.rs
@@ -95,7 +95,7 @@ fn sanity_check(target_dir: &Path) -> Result<()> {
 /// Creates a file with a newly generated ed25519 private key inside.
 fn init_secret_file(key_pair_path: &Path) -> Result<()> {
     let key_pair = KeyPair::new();
-    write_key_pair(&key_pair_path, &key_pair)?;
+    write_key_pair(key_pair_path, &key_pair)?;
     Ok(())
 }
 

--- a/src/commands/init.rs
+++ b/src/commands/init.rs
@@ -7,7 +7,7 @@ use dialoguer::Input;
 use p2panda_rs::identity::KeyPair;
 use p2panda_rs::schema::validate::validate_name;
 
-use crate::constants::{LOCK_FILE_NAME, PRIVATE_KEY_FILE_NAME, SCHEMA_FILE_NAME};
+use crate::constants::{PRIVATE_KEY_FILE_NAME, SCHEMA_FILE_NAME};
 use crate::utils::files::{absolute_path, write_file};
 use crate::utils::key_pair::write_key_pair;
 use crate::utils::terminal::{print_title, print_variable};
@@ -62,20 +62,6 @@ fn sanity_check(target_dir: &Path) -> Result<()> {
         );
     }
 
-    // Check if files already exist
-    [SCHEMA_FILE_NAME, LOCK_FILE_NAME]
-        .iter()
-        .try_for_each(|file_name| {
-            let mut path = target_dir.to_path_buf();
-            path.push(file_name);
-
-            if path.exists() {
-                bail!("Found an already existing '{file_name}' file")
-            }
-
-            Ok(())
-        })?;
-
     Ok(())
 }
 
@@ -88,6 +74,8 @@ fn init_secret_file(target_dir: &Path) -> Result<()> {
 
     if !path.exists() {
         write_key_pair(&path, &key_pair)?;
+    } else {
+        println!("Do not create private key file as it already exists");
     }
 
     Ok(())
@@ -101,16 +89,20 @@ fn init_schema_file(target_dir: &Path, schema_name: &str) -> Result<()> {
         path
     };
 
-    write_file(
-        schema_path,
-        &format!(
-            r#"[{schema_name}]
+    if !schema_path.exists() {
+        write_file(
+            schema_path,
+            &format!(
+                r#"[{schema_name}]
 description = "Write about your schema here"
 
 [{schema_name}.fields]
 some_field = {{ type = "str" }}"#
-        ),
-    )?;
+            ),
+        )?;
+    } else {
+        println!("Do not create schema file as it already exists");
+    }
 
     Ok(())
 }

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
 /// File name of file containing signed and encoded p2panda entries and operations.
+#[allow(dead_code)]
 pub const LOCK_FILE_NAME: &str = "schema.lock";
 
 /// File name of file containing hex-encoded ed25519 private key.


### PR DESCRIPTION
Before: Could only initialise private key and schema file in empty folder
After: When private key file is missing it initialises one, if schema file is missing it initialises one.